### PR TITLE
Update EmbedVideo.Services.php

### DIFF
--- a/EmbedVideo.Services.php
+++ b/EmbedVideo.Services.php
@@ -136,6 +136,12 @@ $wgEmbedVideoServiceList = array(
 				'frameborder="0" allowfullscreen="true"></iframe>',
 		'default_ratio' => 16 / 9
 	),
+	'youtubeimg' => array(
+		'extern' =>
+			'<a href="http://www.youtube.com/watch?v=$2" target="_blank"> ' .
+				'<img src="http://img.youtube.com/vi/$2/0.jpg" width="$3" height="$4" /> ' .
+				'</a>',
+	),
 	'videomaten' => array(
 		'extern' => '<object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" codebase="http://fpdownload.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=8,0,0,0" width="300" height="200" id="videomat" align="middle"><param name="allowScriptAccess" value="sameDomain" /><param name="movie" value="http://89.160.51.62/recordMe/play.swf?id=$2" /><param name="loop" value="false" /><param name="quality" value="high" /><param name="bgcolor" value="#ffffff" /><embed src="http://89.160.51.62/recordMe/play.swf?id=$2" loop="false" quality="high" bgcolor="#ffffff" width="$3" height="$4" name="videomat" align="middle" allowScriptAccess="sameDomain" type="application/x-shockwave-flash" pluginspage="http://www.macromedia.com/go/getflashplayer" /></object>',
 		'default_ratio' => 300 / 200


### PR DESCRIPTION
added "youtubeimg".
convenient for pages with lots of videos: instead of the iframe is loaded only screenshot.
the sample page, where this patch works: http://ruxpert.ru/Музыка_и_песни_о_России
